### PR TITLE
Update to futures-0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["signal", "reactive", "frp", "futures"]
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = "0.2.0-beta"
-futures-channel = "0.2.0-beta"
-futures-util = "0.2.0-beta"
+futures-core = "0.2.0"
+futures-channel = "0.2.0"
+futures-util = "0.2.0"
 discard = "1.0.3"
 # TODO make this optional
 serde = "1.0.27"
 
 [dev-dependencies]
-futures-executor = "0.2.0-beta"
+futures-executor = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["signal", "reactive", "frp", "futures"]
 categories = ["asynchronous"]
 
 [dependencies]
-futures = "0.1.18"
+futures = "0.2.0-beta"
 discard = "1.0.3"
 # TODO make this optional
 serde = "1.0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ keywords = ["signal", "reactive", "frp", "futures"]
 categories = ["asynchronous"]
 
 [dependencies]
-futures = "0.2.0-beta"
+futures-core = "0.2.0-beta"
+futures-channel = "0.2.0-beta"
+futures-executor = "0.2.0-beta"
+futures-util = "0.2.0-beta"
 discard = "1.0.3"
 # TODO make this optional
 serde = "1.0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ categories = ["asynchronous"]
 [dependencies]
 futures-core = "0.2.0-beta"
 futures-channel = "0.2.0-beta"
-futures-executor = "0.2.0-beta"
 futures-util = "0.2.0-beta"
 discard = "1.0.3"
 # TODO make this optional
 serde = "1.0.27"
+
+[dev-dependencies]
+futures-executor = "0.2.0-beta"

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,8 +1,8 @@
 use super::signal::Signal;
 use std::rc::Rc;
 use std::cell::RefCell;
-use futures::Async;
-use futures::task::Context;
+use futures_core::Async;
+use futures_core::task::Context;
 
 
 pub fn unwrap_mut<A>(x: &mut Option<A>) -> &mut A {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 #![recursion_limit="128"]
 
-extern crate futures;
 extern crate discard;
 extern crate serde;
+
+extern crate futures_channel;
+extern crate futures_core;
+extern crate futures_executor;
+extern crate futures_util;
 
 pub mod signal;
 pub mod signal_vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,10 @@ extern crate serde;
 
 extern crate futures_channel;
 extern crate futures_core;
-extern crate futures_executor;
 extern crate futures_util;
+
+#[cfg(test)]
+extern crate futures_executor;
 
 pub mod signal;
 pub mod signal_vec;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,9 +1,10 @@
 use std::rc::{Rc, Weak};
 use std::cell::{Cell, RefCell};
-use futures::task::{Context, Waker};
-use futures::{Async, Poll};
-use futures::future::{Future, IntoFuture};
-use futures::stream::{Stream, StreamExt, ForEach};
+use futures_core::task::{Context, Waker};
+use futures_core::{Async, Poll};
+use futures_core::future::{Future, IntoFuture};
+use futures_core::stream::{Stream};
+use futures_util::stream::{StreamExt, ForEach};
 use discard::{Discard, DiscardOnDrop};
 use signal_vec::{VecChange, SignalVec};
 
@@ -201,7 +202,7 @@ impl<A, B> Future for CancelableFuture<A, B>
 
 
 // TODO figure out a more efficient way to implement this
-// TODO this should be implemented in the futures crate
+// TODO this should be implemented in the futures_core crate
 #[inline]
 pub fn cancelable_future<A, B>(future: A, when_cancelled: B) -> (DiscardOnDrop<CancelableFutureHandle>, CancelableFuture<A, B>)
     where A: Future,
@@ -461,8 +462,8 @@ pub mod unsync {
     use std;
     use std::rc::{Rc, Weak};
     use std::cell::{Cell, RefCell, RefMut, Ref};
-    use futures::Async;
-    use futures::task::{Context, Waker};
+    use futures_core::Async;
+    use futures_core::task::{Context, Waker};
     use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
@@ -801,9 +802,9 @@ mod tests {
     use super::Signal;
     use super::unsync::Mutable;
 
-    use futures::Async;
-    use futures::executor::LocalPool;
-    use futures::task::{Context, LocalMap, Waker, Wake};
+    use futures_core::Async;
+    use futures_core::task::{Context, LocalMap, Waker, Wake};
+    use futures_executor::LocalPool;
 
     use std::sync::Arc;
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,8 +1,9 @@
 use std::rc::{Rc, Weak};
 use std::cell::{Cell, RefCell};
-use futures::{Async, Poll, task};
+use futures::task::{Context, Waker};
+use futures::{Async, Poll};
 use futures::future::{Future, IntoFuture};
-use futures::stream::{Stream, ForEach};
+use futures::stream::{Stream, StreamExt, ForEach};
 use discard::{Discard, DiscardOnDrop};
 use signal_vec::{VecChange, SignalVec};
 
@@ -10,7 +11,7 @@ use signal_vec::{VecChange, SignalVec};
 pub trait Signal {
     type Item;
 
-    fn poll(&mut self) -> Async<Option<Self::Item>>;
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>>;
 
     #[inline]
     fn to_stream(self) -> SignalStream<Self>
@@ -73,7 +74,7 @@ pub trait Signal {
 
     #[inline]
     // TODO file Rust bug about bad error message when `callback` isn't marked as `mut`
-    fn for_each<F, U>(self, callback: F) -> ForEach<SignalStream<Self>, F, U>
+    fn for_each<F, U>(self, callback: F) -> ForEach<SignalStream<Self>, U, F>
         where F: FnMut(Self::Item) -> U,
               // TODO allow for errors ?
               U: IntoFuture<Item = (), Error = ()>,
@@ -111,8 +112,8 @@ impl<F: ?Sized + Signal> Signal for ::std::boxed::Box<F> {
     type Item = F::Item;
 
     #[inline]
-    fn poll(&mut self) -> Async<Option<Self::Item>> {
-        (**self).poll()
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
+        (**self).poll(cx)
     }
 }
 
@@ -125,7 +126,7 @@ impl<A> Signal for Always<A> {
     type Item = A;
 
     #[inline]
-    fn poll(&mut self) -> Async<Option<Self::Item>> {
+    fn poll(&mut self, _: &mut Context) -> Async<Option<Self::Item>> {
         Async::Ready(self.value.take())
     }
 }
@@ -140,7 +141,7 @@ pub fn always<A>(value: A) -> Always<A> {
 
 struct CancelableFutureState {
     is_cancelled: Cell<bool>,
-    task: RefCell<Option<task::Task>>,
+    waker: RefCell<Option<Waker>>,
 }
 
 
@@ -153,11 +154,11 @@ impl Discard for CancelableFutureHandle {
         if let Some(state) = self.state.upgrade() {
             state.is_cancelled.set(true);
 
-            let mut borrow = state.task.borrow_mut();
+            let mut borrow = state.waker.borrow_mut();
 
-            if let Some(task) = borrow.take() {
+            if let Some(waker) = borrow.take() {
                 drop(borrow);
-                task.notify();
+                waker.wake();
             }
         }
     }
@@ -179,7 +180,7 @@ impl<A, B> Future for CancelableFuture<A, B>
 
     // TODO should this inline ?
     #[inline]
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(&mut self, cx: &mut Context) -> Poll<Self::Item, Self::Error> {
         if self.state.is_cancelled.get() {
             let future = self.future.take().unwrap();
             let callback = self.when_cancelled.take().unwrap();
@@ -187,10 +188,10 @@ impl<A, B> Future for CancelableFuture<A, B>
             Ok(Async::Ready(callback(future)))
 
         } else {
-            match self.future.as_mut().unwrap().poll() {
-                Ok(Async::NotReady) => {
-                    *self.state.task.borrow_mut() = Some(task::current());
-                    Ok(Async::NotReady)
+            match self.future.as_mut().unwrap().poll(cx) {
+                Ok(Async::Pending) => {
+                    *self.state.waker.borrow_mut() = Some(cx.waker().clone());
+                    Ok(Async::Pending)
                 },
                 a => a,
             }
@@ -208,7 +209,7 @@ pub fn cancelable_future<A, B>(future: A, when_cancelled: B) -> (DiscardOnDrop<C
 
     let state = Rc::new(CancelableFutureState {
         is_cancelled: Cell::new(false),
-        task: RefCell::new(None),
+        waker: RefCell::new(None),
     });
 
     let cancel_handle = DiscardOnDrop::new(CancelableFutureHandle {
@@ -235,8 +236,8 @@ impl<A: Signal> Stream for SignalStream<A> {
     type Error = ();
 
     #[inline]
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        Ok(self.signal.poll())
+    fn poll_next(&mut self, cx: &mut Context) -> Poll<Option<Self::Item>, Self::Error> {
+        Ok(self.signal.poll(cx))
     }
 }
 
@@ -252,8 +253,8 @@ impl<A, B, C> Signal for Map<A, B>
     type Item = C;
 
     #[inline]
-    fn poll(&mut self) -> Async<Option<Self::Item>> {
-        self.signal.poll().map(|opt| opt.map(|value| (self.callback)(value)))
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
+        self.signal.poll(cx).map(|opt| opt.map(|value| (self.callback)(value)))
     }
 }
 
@@ -273,9 +274,9 @@ impl<A> Future for WaitFor<A>
     type Item = ();
     type Error = ();
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(&mut self, cx: &mut Context) -> Poll<Self::Item, Self::Error> {
         loop {
-            return match self.signal.poll() {
+            return match self.signal.poll(cx) {
                 Async::Ready(Some(value)) => if value == self.value {
                     Ok(Async::Ready(()))
 
@@ -285,7 +286,7 @@ impl<A> Future for WaitFor<A>
 
                 // TODO is this correct ?
                 Async::Ready(None) => Err(()),
-                Async::NotReady => Ok(Async::NotReady),
+                Async::Pending => Ok(Async::Pending),
             };
         }
     }
@@ -301,8 +302,8 @@ impl<A, B> SignalVec for SignalSignalVec<A>
     type Item = B;
 
     #[inline]
-    fn poll(&mut self) -> Async<Option<VecChange<B>>> {
-        self.signal.poll().map(|opt| opt.map(|values| VecChange::Replace { values }))
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<VecChange<B>>> {
+        self.signal.poll(cx).map(|opt| opt.map(|values| VecChange::Replace { values }))
     }
 }
 
@@ -323,9 +324,9 @@ impl<A, B, C> Signal for MapDedupe<A, B>
     type Item = C;
 
     // TODO should this use #[inline] ?
-    fn poll(&mut self) -> Async<Option<Self::Item>> {
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
         loop {
-            return match self.signal.poll() {
+            return match self.signal.poll(cx) {
                 Async::Ready(Some(mut value)) => {
                     let has_changed = match self.old_value {
                         Some(ref old_value) => *old_value != value,
@@ -342,7 +343,7 @@ impl<A, B, C> Signal for MapDedupe<A, B>
                     }
                 },
                 Async::Ready(None) => Async::Ready(None),
-                Async::NotReady => Async::NotReady,
+                Async::Pending => Async::Pending,
             }
         }
     }
@@ -362,9 +363,9 @@ impl<A, B, C> Signal for FilterMap<A, B>
 
     // TODO should this use #[inline] ?
     #[inline]
-    fn poll(&mut self) -> Async<Option<Self::Item>> {
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
         loop {
-            return match self.signal.poll() {
+            return match self.signal.poll(cx) {
                 Async::Ready(Some(value)) => match (self.callback)(value) {
                     Some(value) => {
                         self.first = false;
@@ -380,7 +381,7 @@ impl<A, B, C> Signal for FilterMap<A, B>
                     },
                 },
                 Async::Ready(None) => Async::Ready(None),
-                Async::NotReady => Async::NotReady,
+                Async::Pending => Async::Pending,
             }
         }
     }
@@ -395,24 +396,24 @@ pub struct Flatten<A: Signal> {
 // Poll parent => Has inner   => Poll inner  => Output
 // --------------------------------------------------------
 // Some(inner) =>             => Some(value) => Some(value)
-// Some(inner) =>             => None        => NotReady
-// Some(inner) =>             => NotReady    => NotReady
+// Some(inner) =>             => None        => Pending
+// Some(inner) =>             => Pending    => Pending
 // None        => Some(inner) => Some(value) => Some(value)
 // None        => Some(inner) => None        => None
-// None        => Some(inner) => NotReady    => NotReady
+// None        => Some(inner) => Pending    => Pending
 // None        => None        =>             => None
-// NotReady    => Some(inner) => Some(value) => Some(value)
-// NotReady    => Some(inner) => None        => NotReady
-// NotReady    => Some(inner) => NotReady    => NotReady
-// NotReady    => None        =>             => NotReady
+// Pending    => Some(inner) => Some(value) => Some(value)
+// Pending    => Some(inner) => None        => Pending
+// Pending    => Some(inner) => Pending    => Pending
+// Pending    => None        =>             => Pending
 impl<A> Signal for Flatten<A>
     where A: Signal,
           A::Item: Signal {
     type Item = <<A as Signal>::Item as Signal>::Item;
 
     #[inline]
-    fn poll(&mut self) -> Async<Option<Self::Item>> {
-        let done = match self.signal.as_mut().map(|signal| signal.poll()) {
+    fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
+        let done = match self.signal.as_mut().map(|signal| signal.poll(cx)) {
             None => true,
             Some(Async::Ready(None)) => {
                 self.signal = None;
@@ -422,17 +423,17 @@ impl<A> Signal for Flatten<A>
                 self.inner = Some(inner);
                 false
             },
-            Some(Async::NotReady) => false,
+            Some(Async::Pending) => false,
         };
 
         let poll = match self.inner {
-            Some(ref mut inner) => inner.poll(),
+            Some(ref mut inner) => inner.poll(cx),
 
             None => if done {
                 return Async::Ready(None);
 
             } else {
-                return Async::NotReady;
+                return Async::Pending;
             }
         };
 
@@ -444,7 +445,7 @@ impl<A> Signal for Flatten<A>
                     Async::Ready(None)
 
                 } else {
-                    Async::NotReady
+                    Async::Pending
                 }
             },
 
@@ -460,8 +461,8 @@ pub mod unsync {
     use std;
     use std::rc::{Rc, Weak};
     use std::cell::{Cell, RefCell, RefMut, Ref};
-    use futures::{Async, task};
-    use futures::task::Task;
+    use futures::Async;
+    use futures::task::{Context, Waker};
     use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
@@ -478,11 +479,11 @@ pub mod unsync {
                 if let Some(receiver) = receiver.upgrade() {
                     receiver.has_changed.set(true);
 
-                    let mut borrow = receiver.task.borrow_mut();
+                    let mut borrow = receiver.waker.borrow_mut();
 
-                    if let Some(task) = borrow.take() {
+                    if let Some(waker) = borrow.take() {
                         drop(borrow);
-                        task.notify();
+                        waker.wake();
                     }
 
                     true
@@ -496,7 +497,7 @@ pub mod unsync {
 
     struct MutableSignalState<A> {
         has_changed: Cell<bool>,
-        task: RefCell<Option<Task>>,
+        waker: RefCell<Option<Waker>>,
         // TODO change this to Weak ?
         state: Rc<RefCell<MutableState<A>>>,
     }
@@ -505,7 +506,7 @@ pub mod unsync {
         fn new(mutable_state: &Rc<RefCell<MutableState<A>>>) -> Rc<Self> {
             let state = Rc::new(MutableSignalState {
                 has_changed: Cell::new(true),
-                task: RefCell::new(None),
+                waker: RefCell::new(None),
                 state: mutable_state.clone(),
             });
 
@@ -655,7 +656,7 @@ pub mod unsync {
     impl<A: Copy> Signal for MutableSignal<A> {
         type Item = A;
 
-        fn poll(&mut self) -> Async<Option<Self::Item>> {
+        fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
             if self.0.has_changed.replace(false) {
                 Async::Ready(Some(self.0.state.borrow().value))
 
@@ -663,8 +664,8 @@ pub mod unsync {
                 Async::Ready(None)
 
             } else {
-                *self.0.task.borrow_mut() = Some(task::current());
-                Async::NotReady
+                *self.0.waker.borrow_mut() = Some(cx.waker().clone());
+                Async::Pending
             }
         }
     }
@@ -685,7 +686,7 @@ pub mod unsync {
         type Item = A;
 
         // TODO code duplication with MutableSignal::poll
-        fn poll(&mut self) -> Async<Option<Self::Item>> {
+        fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
             if self.0.has_changed.replace(false) {
                 Async::Ready(Some(self.0.state.borrow().value.clone()))
 
@@ -693,8 +694,8 @@ pub mod unsync {
                 Async::Ready(None)
 
             } else {
-                *self.0.task.borrow_mut() = Some(task::current());
-                Async::NotReady
+                *self.0.waker.borrow_mut() = Some(cx.waker().clone());
+                Async::Pending
             }
         }
     }
@@ -702,15 +703,15 @@ pub mod unsync {
 
     struct Inner<A> {
         value: Option<A>,
-        task: Option<task::Task>,
+        waker: Option<Waker>,
         dropped: bool,
     }
 
     impl<A> Inner<A> {
         fn notify(mut borrow: RefMut<Self>) {
-            if let Some(task) = borrow.task.take() {
+            if let Some(waker) = borrow.waker.take() {
                 drop(borrow);
-                task.notify();
+                waker.wake();
             }
         }
     }
@@ -757,7 +758,7 @@ pub mod unsync {
         type Item = A;
 
         #[inline]
-        fn poll(&mut self) -> Async<Option<Self::Item>> {
+        fn poll(&mut self, cx: &mut Context) -> Async<Option<Self::Item>> {
             let mut inner = self.inner.borrow_mut();
 
             // TODO is this correct ?
@@ -766,8 +767,8 @@ pub mod unsync {
                     Async::Ready(None)
 
                 } else {
-                    inner.task = Some(task::current());
-                    Async::NotReady
+                    inner.waker = Some(cx.waker().clone());
+                    Async::Pending
                 },
 
                 a => Async::Ready(a),
@@ -778,7 +779,7 @@ pub mod unsync {
     pub fn channel<A>(initial_value: A) -> (Sender<A>, Receiver<A>) {
         let inner = Rc::new(RefCell::new(Inner {
             value: Some(initial_value),
-            task: None,
+            waker: None,
             dropped: false,
         }));
 
@@ -792,4 +793,52 @@ pub mod unsync {
 
         (sender, receiver)
     }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::Signal;
+    use super::unsync::Mutable;
+
+    use futures::Async;
+    use futures::executor::LocalPool;
+    use futures::task::{Context, LocalMap, Waker, Wake};
+
+    use std::sync::Arc;
+
+    fn with_noop_context<U, F: FnOnce(&mut Context) -> U>(f: F) -> U {
+
+        // borrowed this design from the futures source
+        struct Noop;
+
+        impl Wake for Noop {
+            fn wake(_: &Arc<Self>) {}
+        }
+
+        let waker = Waker::from(Arc::new(Noop));
+
+        let pool = LocalPool::new();
+        let mut exec = pool.executor();
+        let mut map = LocalMap::new();
+        let mut cx = Context::new(&mut map, &waker, &mut exec);
+
+        f(&mut cx)
+    }
+
+    #[test]
+    fn test_mutable() {
+        let mutable = Mutable::new(1);
+        let mut s = mutable.signal();
+
+        with_noop_context(|cx| {
+            assert_eq!(s.poll(cx), Async::Ready(Some(1)));
+            assert_eq!(s.poll(cx), Async::Pending);
+
+            mutable.set(5);
+            assert_eq!(s.poll(cx), Async::Ready(Some(5)));
+            assert_eq!(s.poll(cx), Async::Pending);
+        });
+    }
+
 }

--- a/src/signal_vec.rs
+++ b/src/signal_vec.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
-use futures::task::Context;
-use futures::{Stream, StreamExt, Poll, Async};
-use futures::stream::ForEach;
-use futures::future::IntoFuture;
+use futures_core::task::Context;
+use futures_core::{Stream, Poll, Async};
+use futures_core::future::IntoFuture;
+use futures_util::stream::{StreamExt, ForEach};
 use signal::Signal;
 
 
@@ -698,9 +698,9 @@ pub mod unsync {
     use super::{SignalVec, VecChange};
     use std::rc::Rc;
     use std::cell::{RefCell, Ref};
-    use futures::channel::mpsc;
-    use futures::task::Context;
-    use futures::{Async, Stream};
+    use futures_channel::mpsc;
+    use futures_core::{Async, Stream};
+    use futures_core::task::Context;
     use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
@@ -1080,8 +1080,8 @@ pub mod unsync {
 
 #[cfg(test)]
 mod tests {
-    use futures::{Future, Poll};
-    use futures::executor::block_on;
+    use futures_core::{Future, Poll};
+    use futures_executor::block_on;
     use super::*;
 
     struct Tester<A> {

--- a/tests/map_macro.rs
+++ b/tests/map_macro.rs
@@ -1,6 +1,8 @@
 #![recursion_limit="128"]
 
-extern crate futures;
+extern crate futures_core;
+extern crate futures_executor;
+extern crate futures_util;
 
 #[macro_use]
 extern crate futures_signals;
@@ -10,10 +12,11 @@ macro_rules! map_tests {
     ($name:ident, ($($ref:tt)+), ($($arg:tt)+)) => {
         #[cfg(test)]
         mod $name {
+            use futures_core::Poll;
+            use futures_executor::block_on;
+            use futures_util::future::poll_fn;
+
             use futures_signals::signal::{Signal, always};
-            use futures::executor::block_on;
-            use futures::future::poll_fn;
-            use futures::Poll;
 
             // NB it's not a problem to block on an Always because they always return Async::Ready!
             fn poll_always<S: Signal>(signal: &mut S) -> Option<S::Item> {

--- a/tests/map_macro.rs
+++ b/tests/map_macro.rs
@@ -5,14 +5,22 @@ extern crate futures;
 #[macro_use]
 extern crate futures_signals;
 
-
 #[macro_export]
 macro_rules! map_tests {
     ($name:ident, ($($ref:tt)+), ($($arg:tt)+)) => {
         #[cfg(test)]
         mod $name {
-            use futures::Async;
             use futures_signals::signal::{Signal, always};
+            use futures::executor::block_on;
+            use futures::future::poll_fn;
+            use futures::Poll;
+
+            // NB it's not a problem to block on an Always because they always return Async::Ready!
+            fn poll_always<S: Signal>(signal: &mut S) -> Option<S::Item> {
+                block_on(poll_fn(
+                    |cx| -> Poll<Option<S::Item>, ()> { Ok(signal.poll(cx)) }
+                )).unwrap()
+            }
 
             #[test]
             fn ident_1() {
@@ -23,8 +31,8 @@ macro_rules! map_tests {
                     a + 1
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(2)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(2));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -38,8 +46,8 @@ macro_rules! map_tests {
                     a + b
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(3)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(3));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -55,8 +63,8 @@ macro_rules! map_tests {
                     a + b + c
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(6)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(6));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -74,8 +82,8 @@ macro_rules! map_tests {
                     a + b + c + d
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(10)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(10));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -95,8 +103,8 @@ macro_rules! map_tests {
                     a + b + c + d + e
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(15)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(15));
+                assert_eq!(poll_always(&mut s), None);
             }
 
 
@@ -109,8 +117,8 @@ macro_rules! map_tests {
                     a + 1
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(2)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(2));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -124,8 +132,8 @@ macro_rules! map_tests {
                     a + b
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(3)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(3));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -141,8 +149,8 @@ macro_rules! map_tests {
                     a + b + c
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(6)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(6));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -160,8 +168,8 @@ macro_rules! map_tests {
                     a + b + c + d
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(10)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(10));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -181,8 +189,8 @@ macro_rules! map_tests {
                     a + b + c + d + e
                 });
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(15)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(15));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -195,8 +203,8 @@ macro_rules! map_tests {
                     }
                 };
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(3)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(3));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -212,8 +220,8 @@ macro_rules! map_tests {
                     }
                 };
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(10)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(10));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -232,8 +240,8 @@ macro_rules! map_tests {
                     }
                 };
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(21)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(21));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -255,8 +263,8 @@ macro_rules! map_tests {
                     }
                 };
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(36)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(36));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -281,8 +289,8 @@ macro_rules! map_tests {
                     }
                 };
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(55)));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(55));
+                assert_eq!(poll_always(&mut s), None);
             }
 
             #[test]
@@ -318,8 +326,8 @@ macro_rules! map_tests {
                     ((c1.clone(), c2.clone()), (c3.clone(), c4.clone()), *l, *r, a.clone(), *b, *c, *d, e.clone(), (c5.clone(), c6.clone()))
                 };
 
-                assert_eq!(Signal::poll(&mut s), Async::Ready(Some(((Cloner { count: 1 }, Cloner { count: 1 }), (Cloner { count: 1 }, Cloner { count: 1 }), 0, 0, Cloner { count: 1 }, 2, 3, 4, Cloner { count: 1 }, (Cloner { count: 1 }, Cloner { count: 1 })))));
-                assert_eq!(Signal::poll(&mut s), Async::Ready(None));
+                assert_eq!(poll_always(&mut s), Some(((Cloner { count: 1 }, Cloner { count: 1 }), (Cloner { count: 1 }, Cloner { count: 1 }), 0, 0, Cloner { count: 1 }, 2, 3, 4, Cloner { count: 1 }, (Cloner { count: 1 }, Cloner { count: 1 }))));
+                assert_eq!(poll_always(&mut s), None);
             }
         }
     };


### PR DESCRIPTION
I was having a look again at the `Broadcaster` and how to get that internal task going, and realised that futures-0.2 is changing a lot of the task api. (`task::current()` is replaced by `Context`s, for example).

Hence I decided to do this as a precursor to the `Broadcaster` work. I actually had to change not too much, save for:

1. `{Signal, SignalVec}::poll()` now take a `cx: &mut Context` argument, like the new `Future`s.
2. Where signals were internally storing `futures::task::Task`s, now they store `futures::task::Waker`s.

As a bonus I finally grokked `futures` enough to be able to implement a test for `unsync::Mutable`!

---

There might be more to do; namely:

1. futures-0.2 doesn't have `futures::sync` and `futures::unsync` any more. I'm not entirely sure what happened, I think possibly there are now only the `sync` variants? Perhaps `unsync::Mutable` should be adjusted to match.
2. `Stream::poll()` renamed to `Stream::poll_next()`. Given this precendent is `SignalVec::poll()` perhaps appropriate to name as `SignalVec::poll_changes()` now?

Hope you like it! 😄 


