### PR TITLE
Make `serde` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ futures-core-preview = "0.3.0-alpha.15"
 futures-channel-preview = "0.3.0-alpha.15"
 futures-util-preview = "0.3.0-alpha.15"
 discard = "1.0.3"
-# TODO make this optional
-serde = "1.0.27"
+serde = { version = "1.0.98", optional = true }
 
 [dev-dependencies]
 futures-preview = "0.3.0-alpha.15"

--- a/src/signal/mutable.rs
+++ b/src/signal/mutable.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Weak, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 // TODO use parking_lot ?
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Poll, Waker, Context};
+#[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
@@ -308,6 +309,7 @@ impl<A> fmt::Debug for Mutable<A> where A: fmt::Debug {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T> Serialize for Mutable<T> where T: Serialize {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
@@ -315,6 +317,7 @@ impl<T> Serialize for Mutable<T> where T: Serialize {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for Mutable<T> where T: Deserialize<'de> {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {

--- a/src/signal_vec.rs
+++ b/src/signal_vec.rs
@@ -1879,6 +1879,7 @@ mod mutable_vec {
     use std::task::{Poll, Context};
     use futures_channel::mpsc;
     use futures_util::stream::StreamExt;
+    #[cfg(feature = "serde")]
     use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
@@ -2410,6 +2411,7 @@ mod mutable_vec {
         }
     }
 
+    #[cfg(feature = "serde")]
     impl<T> Serialize for MutableVec<T> where T: Serialize {
         #[inline]
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
@@ -2417,6 +2419,7 @@ mod mutable_vec {
         }
     }
 
+    #[cfg(feature = "serde")]
     impl<'de, T> Deserialize<'de> for MutableVec<T> where T: Deserialize<'de> {
         #[inline]
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {


### PR DESCRIPTION
Just in case if the following `TODO` https://github.com/Pauan/rust-signals/blob/4d63468e4918912d2ffc2bb8ce0e4d8ec841c321/Cargo.toml#L19-L20 is still relevant...