### PR TITLE
Update how we convert ArcWake into Waker

### DIFF
--- a/src/signal/broadcaster.rs
+++ b/src/signal/broadcaster.rs
@@ -4,7 +4,7 @@ use std::marker::Unpin;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Poll, Waker, Context};
-use futures_util::task::ArcWake;
+use futures_util::task::{self, ArcWake};
 
 
 #[derive(Debug)]
@@ -98,7 +98,7 @@ impl<A> BroadcasterInnerState<A> where A: Signal {
     // to wake in the future if it is in Pending state.
     fn poll_underlying(&mut self, notifier: Arc<BroadcasterNotifier>) {
         // TODO is this the best way to do this ?
-        let waker = ArcWake::into_waker(notifier);
+        let waker = task::waker(notifier);
         let cx = &mut Context::from_waker(&waker);
 
         loop {


### PR DESCRIPTION
Looks like futures-util was updated, and this fell behind. 
Relevant commit on the futures side: https://github.com/rust-lang-nursery/futures-rs/commit/e597a6cfbf6e4705604ada9cd39ad7f7ece234c0

Docs: https://github.com/rust-lang-nursery/futures-rs/commit/af434e1d495264dfd7f8b5094b69fbba490d423e