### PR TITLE
Adds additional functionality to MutableBTreeMap

### DIFF
--- a/src/signal_map.rs
+++ b/src/signal_map.rs
@@ -344,11 +344,15 @@ mod mutable_btree_map {
             let x = self.change(|| (key, value));
 
             if let Some(value) = self.values.insert(key, value) {
-                self.notify_clone(x, |(key, value)| MapDiff::Update { key, value });
+                if x.is_some() {
+                    self.notify(|| MapDiff::Update { key, value });
+                }
                 Some(value)
 
             } else {
-                self.notify_clone(x, |(key, value)| MapDiff::Insert { key, value });
+                if x.is_some() {
+                    self.notify(|| MapDiff::Insert { key, value });
+                }
                 None
             }
         }

--- a/tests/mutable_btree_map.rs
+++ b/tests/mutable_btree_map.rs
@@ -1,0 +1,98 @@
+use std::task::Poll;
+use futures_signals::signal_map::{MapDiff, MutableBTreeMap, MutableBTreeMapLockMut};
+
+mod util;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TestValueType {
+    inner: i32,
+}
+
+fn emits_diffs<K, V, F>(f: F, polls: Vec<Poll<Option<MapDiff<K, V>>>>)
+    where F: FnOnce(&mut MutableBTreeMapLockMut<K, V>), 
+          K: Ord + Copy + std::fmt::Debug,
+          V: Eq + Copy + std::fmt::Debug {
+
+    let map = MutableBTreeMap::<K, V>::new();
+    assert_eq!(util::get_signal_map_polls(map.signal_map(), || {
+        {
+            let mut v = map.lock_mut();
+            f(&mut v);
+        }
+        drop(map);
+    }), polls);
+}
+
+fn emits_diffs_cloned<K, V, F>(f: F, polls: Vec<Poll<Option<MapDiff<K, V>>>>)
+    where F: FnOnce(&mut MutableBTreeMapLockMut<K, V>), 
+          K: Ord + Clone + std::fmt::Debug,
+          V: Eq + Clone + std::fmt::Debug {
+
+    let map = MutableBTreeMap::<K, V>::new();
+    assert_eq!(util::get_signal_map_polls(map.signal_map_cloned(), || {
+        {
+            let mut v = map.lock_mut();
+            f(&mut v);
+        }
+        drop(map);
+    }), polls);
+}
+
+#[test]
+fn insert_and_remove() {
+    let m = MutableBTreeMap::<u8, i8>::new();
+    let mut writer = m.lock_mut();
+    writer.insert(8, -8);
+    assert_eq!(writer.get(&8).unwrap(), &-8);
+
+    writer.insert(8, 100);
+    assert_eq!(writer.get(&8).unwrap(), &100);
+
+    writer.remove(&8);
+    assert_eq!(writer.get(&8), None);
+}
+
+#[test]
+fn clear() {
+    let m = MutableBTreeMap::<u8, i8>::new();
+    let mut writer = m.lock_mut();
+    writer.insert(80, -80);
+    assert_eq!(writer.get(&80).unwrap(), &-80);
+
+    writer.clear();
+    assert_eq!(writer.get(&8), None);
+}
+
+#[test]
+fn insert_cloned() {
+    let m = MutableBTreeMap::<&'static str, TestValueType>::new();
+    let mut writer = m.lock_mut();
+    writer.insert_cloned("test", TestValueType {inner: 294});
+    assert_eq!(writer.get(&"test").unwrap(), &TestValueType {inner: 294});
+}
+
+#[test]
+fn signal_map() {
+    emits_diffs(|writer| {
+        writer.insert(1, 1);
+        writer.remove(&1);
+    }, vec![
+        Poll::Pending, 
+        Poll::Ready(Some(MapDiff::Insert { key: 1, value: 1 })),
+        Poll::Ready(Some(MapDiff::Remove { key: 1 })),
+        Poll::Ready(None)
+    ]);
+}
+
+#[test]
+fn signal_map_cloned() {
+    emits_diffs_cloned(|writer| {
+        writer.insert_cloned(1, TestValueType {inner: 42});
+        writer.remove(&1);
+    }, vec![
+        Poll::Pending, 
+        Poll::Ready(Some(MapDiff::Insert { key: 1, value: TestValueType {inner: 42} })),
+        Poll::Ready(Some(MapDiff::Remove { key: 1 })),
+        Poll::Ready(None)
+    ]);
+}

--- a/tests/signal_map.rs
+++ b/tests/signal_map.rs
@@ -1,0 +1,118 @@
+use std::task::Poll;
+use futures_signals::signal_map::{MapDiff, SignalMapExt};
+
+mod util;
+
+#[test]
+fn map_value() {
+    let input = util::Source::new(vec![
+        Poll::Ready(MapDiff::Replace {
+            entries: vec![(1, 1), (2, 1), (3, 2), (4, 3)]
+        }),
+        Poll::Pending,
+        Poll::Ready(MapDiff::Insert {
+            key: 5,
+            value: 5,
+        }),
+        Poll::Ready(MapDiff::Update {
+            key: 1,
+            value: 0,
+        }),
+        Poll::Pending,
+        Poll::Ready(MapDiff::Remove {key: 1}),
+        Poll::Ready(MapDiff::Insert {
+            key: 1,
+            value: 1,
+        }),
+        Poll::Ready(MapDiff::Clear {})
+    ]);
+
+    let output = input.map_value(|value| value * 2);
+
+    util::assert_signal_map_eq(output, vec![
+        Poll::Ready(Some(MapDiff::Replace {
+            entries: vec![(1, 2), (2, 2), (3, 4), (4, 6)]
+        })),
+        Poll::Pending,
+        Poll::Ready(Some(MapDiff::Insert {
+            key: 5,
+            value: 10,
+        })),
+        Poll::Ready(Some(MapDiff::Update {
+            key: 1,
+            value: 0,
+        })),
+        Poll::Pending,
+        Poll::Ready(Some(MapDiff::Remove {key: 1})),
+        Poll::Ready(Some(MapDiff::Insert {
+            key: 1,
+            value: 2,
+        })),
+        Poll::Ready(Some(MapDiff::Clear {})),
+        Poll::Ready(None),
+    ]);
+}
+
+#[test]
+fn watch_key_exists_at_start() {
+    let input = util::Source::new(vec![
+        Poll::Ready(MapDiff::Replace {
+            entries: vec![(1, 1), (2, 1), (3, 2), (4, 3)]
+        }),
+        Poll::Pending,
+        Poll::Ready(MapDiff::Update {
+            key: 1,
+            value: 0,
+        }),
+        Poll::Ready(MapDiff::Update {
+            key: 2,
+            value: 0,
+        }),
+        Poll::Pending,
+        Poll::Ready(MapDiff::Remove {key: 1})
+    ]);
+
+    let output = input.watch_key(1);
+
+    util::assert_signal_eq(output, vec![
+        Poll::Ready(Some(Some(1))),
+        Poll::Pending,
+        Poll::Ready(Some(Some(0))),
+        Poll::Pending,
+        Poll::Pending,
+        Poll::Ready(Some(None)),
+        Poll::Ready(None),
+    ]);
+}
+
+#[test]
+fn watch_key_does_not_exist_at_start() {
+    let input = util::Source::new(vec![
+        Poll::Ready(MapDiff::Replace {
+            entries: vec![(1, 1), (2, 1), (3, 2), (4, 3)]
+        }),
+        Poll::Pending,
+        Poll::Ready(MapDiff::Insert {
+            key: 5,
+            value: 5,
+        }),
+        Poll::Ready(MapDiff::Update {
+            key: 5,
+            value: 0,
+        }),
+        Poll::Pending,
+        Poll::Ready(MapDiff::Clear {})
+    ]);
+
+    let output = input.watch_key(5);
+
+    util::assert_signal_eq(output, vec![
+        Poll::Ready(Some(None)),
+        Poll::Pending,
+        Poll::Ready(Some(Some(5))),
+        Poll::Ready(Some(Some(0))),
+        Poll::Pending,
+        Poll::Ready(Some(None)),
+        Poll::Ready(None),
+    ]);
+}

--- a/tests/signal_map.rs
+++ b/tests/signal_map.rs
@@ -54,7 +54,7 @@ fn map_value() {
 }
 
 #[test]
-fn watch_key_exists_at_start() {
+fn key_cloned_exists_at_start() {
     let input = util::Source::new(vec![
         Poll::Ready(MapDiff::Replace {
             entries: vec![(1, 1), (2, 1), (3, 2), (4, 3)]
@@ -69,24 +69,22 @@ fn watch_key_exists_at_start() {
             value: 0,
         }),
         Poll::Pending,
+        Poll::Pending,
         Poll::Ready(MapDiff::Remove {key: 1})
     ]);
 
-    let output = input.watch_key(1);
+    let output = input.key_cloned(1);
 
     util::assert_signal_eq(output, vec![
         Poll::Ready(Some(Some(1))),
-        Poll::Pending,
         Poll::Ready(Some(Some(0))),
         Poll::Pending,
-        Poll::Pending,
-        Poll::Ready(Some(None)),
         Poll::Ready(None),
     ]);
 }
 
 #[test]
-fn watch_key_does_not_exist_at_start() {
+fn key_cloned_does_not_exist_at_start() {
     let input = util::Source::new(vec![
         Poll::Ready(MapDiff::Replace {
             entries: vec![(1, 1), (2, 1), (3, 2), (4, 3)]
@@ -101,18 +99,16 @@ fn watch_key_does_not_exist_at_start() {
             value: 0,
         }),
         Poll::Pending,
+        Poll::Pending,
         Poll::Ready(MapDiff::Clear {})
     ]);
 
-    let output = input.watch_key(5);
+    let output = input.key_cloned(5);
 
     util::assert_signal_eq(output, vec![
         Poll::Ready(Some(None)),
-        Poll::Pending,
-        Poll::Ready(Some(Some(5))),
         Poll::Ready(Some(Some(0))),
         Poll::Pending,
-        Poll::Ready(Some(None)),
         Poll::Ready(None),
     ]);
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -155,6 +155,16 @@ pub fn get_signal_vec_polls<A, F>(signal: A, f: F) -> Vec<Poll<Option<VecDiff<A:
 
 
 #[allow(dead_code)]
+pub fn get_signal_map_polls<A, F>(signal: A, f: F) -> Vec<Poll<Option<MapDiff<A::Key, A::Value>>>>
+    where A: SignalMap,
+          F: FnOnce() {
+    pin_mut!(signal);
+    // TODO is the as_mut correct ?
+    get_polls(f, |cx| Pin::as_mut(&mut signal).poll_map_change(cx))
+}
+
+
+#[allow(dead_code)]
 pub fn get_all_polls<A, B, F>(signal: A, mut initial: B, mut f: F) -> Vec<Poll<Option<A::Item>>> where A: Signal, F: FnMut(&B, &mut Context) -> B {
     let mut output = vec![];
 


### PR DESCRIPTION
Just some quick changes I needed for my own project that I thought might be generally helpful for this library.

- Non-cloned functions on `MutableBTreeMap`, mirroring those on `MutableVec`
  - Including `insert`, `replace`, `entries`, and `signal_map`.
  - These require both the Key and the Value to be copy-able. My guess is that in most use cases Keys already are. 
- Adds a `watch_key` function to `SignalMapExt` that creates a 1D signal out of a particular key on the map.
  - I'm happy to change this name, I know `watch` is a little vague.
  - I think there is potential for something like this on MutableVec as well, but it's more complicated. When items are added or removed from the vector, would existing 'watches' change indices to track the same value, or stay on the same index?
- Added some unit tests to `MutableBTreeMap` and `SignalMapExt`. Mostly testing my new changes but added some tests for existing code as well.