### PR TITLE
Make `serde` an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,15 @@ futures-util = "0.3.0"
 discard = "1.0.3"
 pin-project = "1.0.2"
 # TODO make this optional
-serde = "1.0.98"
-# TODO make this optional
 log = "0.4.14"
+
+[dependencies.serde]
+version = "1.0.98"
+optional = true
 
 [dev-dependencies]
 futures-executor = "0.3.0"
 pin-utils = "0.1.0"
+
+[features]
+default = ["serde"]

--- a/src/signal/mutable.rs
+++ b/src/signal/mutable.rs
@@ -9,7 +9,6 @@ use std::sync::{Arc, Weak, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 // TODO use parking_lot ?
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::task::{Poll, Waker, Context};
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
 #[derive(Debug)]
@@ -348,16 +347,18 @@ impl<A> fmt::Debug for Mutable<A> where A: fmt::Debug {
     }
 }
 
-impl<T> Serialize for Mutable<T> where T: Serialize {
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for Mutable<T> where T: serde::Serialize {
     #[inline]
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
         self.state().lock.read().unwrap().value.serialize(serializer)
     }
 }
 
-impl<'de, T> Deserialize<'de> for Mutable<T> where T: Deserialize<'de> {
+#[cfg(feature = "serde")]
+impl<'de, T> serde::Deserialize<'de> for Mutable<T> where T: serde::Deserialize<'de> {
     #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
         T::deserialize(deserializer).map(Mutable::new)
     }
 }

--- a/src/signal_map.rs
+++ b/src/signal_map.rs
@@ -307,7 +307,6 @@ mod mutable_btree_map {
     use std::task::{Poll, Context};
     use futures_channel::mpsc;
     use futures_util::stream::StreamExt;
-    use serde::{Serialize, Deserialize, Serializer, Deserializer};
     use crate::signal_vec::{SignalVec, VecDiff};
 
 
@@ -679,16 +678,18 @@ mod mutable_btree_map {
         }
     }
 
-    impl<K, V> Serialize for MutableBTreeMap<K, V> where BTreeMap<K, V>: Serialize {
+    #[cfg(feature = "serde")]
+    impl<K, V> serde::Serialize for MutableBTreeMap<K, V> where BTreeMap<K, V>: serde::Serialize {
         #[inline]
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
             self.0.read().unwrap().values.serialize(serializer)
         }
     }
 
-    impl<'de, K, V> Deserialize<'de> for MutableBTreeMap<K, V> where BTreeMap<K, V>: Deserialize<'de> {
+    #[cfg(feature = "serde")]
+    impl<'de, K, V> serde::Deserialize<'de> for MutableBTreeMap<K, V> where BTreeMap<K, V>: serde::Deserialize<'de> {
         #[inline]
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
             <BTreeMap<K, V>>::deserialize(deserializer).map(MutableBTreeMap::with_values)
         }
     }

--- a/src/signal_vec.rs
+++ b/src/signal_vec.rs
@@ -2134,7 +2134,6 @@ mod mutable_vec {
     use std::task::{Poll, Context};
     use futures_channel::mpsc;
     use futures_util::stream::StreamExt;
-    use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 
     // TODO replace with std::slice::range after it stabilizes
@@ -2759,16 +2758,18 @@ mod mutable_vec {
         }
     }
 
-    impl<T> Serialize for MutableVec<T> where T: Serialize {
+    #[cfg(feature = "serde")]
+    impl<T> serde::Serialize for MutableVec<T> where T: serde::Serialize {
         #[inline]
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
             self.0.read().unwrap().values.serialize(serializer)
         }
     }
 
-    impl<'de, T> Deserialize<'de> for MutableVec<T> where T: Deserialize<'de> {
+    #[cfg(feature = "serde")]
+    impl<'de, T> serde::Deserialize<'de> for MutableVec<T> where T: serde::Deserialize<'de> {
         #[inline]
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
             <Vec<T>>::deserialize(deserializer).map(MutableVec::new_with_values)
         }
     }


### PR DESCRIPTION
Allows `serde` to be disabled as a dependency per #19. It is enabled by default to keep semver compatibility.