### PR TITLE
Mutable: Modify values in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 
-target/
+/target
 **/*.rs.bk
 Cargo.lock


### PR DESCRIPTION
See https://github.com/tokio-rs/tokio/pull/4591 for a discussion why this is useful and mandatory for implementing certain FRP use cases.

Currently, I am using `std::tokio::watch` that I consider more mature than this crate. But I would actually prefer using a dedicated crate with less dependencies for this purpose.