### PR TITLE
Make the `log` crate optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Introducing a `debug` feature to make the [`log` crate](https://crates.io/crates/log) optional.
+
 ## 0.3.25 - (2022-04-18)
 * The `signals::channel` implementation is now lock-free (if the allocator is lock-free).
 * `Broadcaster` now impls `Clone`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["asynchronous", "concurrency", "data-structures"]
 edition = "2018"
 
 [features]
-default = ["serde"]
+default = ["debug", "serde"]
+debug = ["log"]
 
 [dependencies]
 futures-core = "0.3.0"
@@ -20,8 +21,10 @@ futures-channel = "0.3.0"
 futures-util = "0.3.0"
 discard = "1.0.3"
 pin-project = "1.0.2"
-# TODO make this optional
-log = "0.4.14"
+
+[dependencies.log]
+version = "0.4.14"
+optional = true
 
 [dependencies.serde]
 version = "1.0.98"


### PR DESCRIPTION
Relates to https://github.com/Pauan/rust-signals/issues/45.