### PR TITLE
SignalExt::map_value_signal, signal_map::always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 * Fixing bug with `SignalExt::switch_signal_vec`.
 * Adding in `SignalExt::map_value_signal` method.
+* Adding in `signal_map::always` method.
 
 ## 0.3.31 - (2022-09-10)
 * Adding in serde `Serialize` and `Deserialize` for `MapDiff`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 * Fixing bug with `SignalExt::switch_signal_vec`.
+* Adding in `SignalExt::map_value_signal` method.
 
 ## 0.3.31 - (2022-09-10)
 * Adding in serde `Serialize` and `Deserialize` for `MapDiff`.

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -1,4 +1,6 @@
 mod macros;
+// TODO resolve properly
+#[allow(unreachable_pub)]
 pub use self::macros::*;
 
 mod broadcaster;

--- a/tests/signal_map.rs
+++ b/tests/signal_map.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::task::Poll;
 use futures_signals::signal::{self, SignalExt};
 use futures_signals::signal_map::{self, MapDiff, SignalMapExt};
@@ -108,7 +109,9 @@ fn map_value_signal_const_signal() {
 
 #[test]
 fn map_value_signal_const_map() {
-    let map_signal = signal_map::always(vec![(1, 1), (2, 1), (3, 2), (4, 3)]);
+    let map_signal = signal_map::always(
+        BTreeMap::from([(1, 1), (2, 1), (3, 2), (4, 3)])
+    );
 
     let output = map_signal.map_value_signal(|value| {
         let input = util::Source::new(vec![


### PR DESCRIPTION
- Add `SignalExt::map_value_signal`.
   - Inspired by `SignalVecExt::map_signal`.
   - New tests `map_value_signal_const_signal` and `map_value_signal_const_map`. Tested also manually in my app.
   - Not sure if we want to change it to `SignalExt::map_signal` or `SignalExt::map_entry_signal` and pass also `Key` or `&Key` into the callback.
    
- Add `signal_map::always`.
  - Inspired by `signal_vec::always`. 

- Update `CHANGELOG.md`.

- _Notes_
   - `cargo fmt (--all)` was formatting too much code so I just tried to follow the code style manually.
   - I had to disable one linter in `src/signal/mod.rs` to compile the project (see the related `TODO`).
   - I've found a breaking change in previous commits. The code `map_ref! .... => { ... return x ... }` no longer works, it has to be replaced with the code like `map_ref! .... => 'block: { ... break 'block x ... }`.