### PR TITLE
Let `Mutable::set` take Into<A>

### DIFF
--- a/src/signal/mutable.rs
+++ b/src/signal/mutable.rs
@@ -287,10 +287,10 @@ impl<A> Mutable<A> {
         state2.notify(true);
     }
 
-    pub fn set(&self, value: A) {
+    pub fn set<V: Into<A>>(&self, value: V) {
         let mut state = self.state().lock.write().unwrap();
 
-        state.value = value;
+        state.value = value.into();
 
         state.notify(true);
     }
@@ -321,7 +321,7 @@ impl<A> From<A> for Mutable<A> {
         Mutable(ReadOnlyMutable(Arc::new(MutableState {
             senders: AtomicUsize::new(1),
             lock: RwLock::new(MutableLockState {
-                value: value.into(),
+                value,
                 signals: vec![],
             }),
         })))

--- a/src/signal_vec.rs
+++ b/src/signal_vec.rs
@@ -3304,8 +3304,8 @@ mod mutable_vec {
 
         // TODO replace this with something else, like entry or IndexMut or whatever
         #[inline]
-        pub fn set(&mut self, index: usize, value: A) {
-            self.lock.set_copy(index, value)
+        pub fn set<V: Into<A>>(&mut self, index: usize, value: V) {
+            self.lock.set_copy(index, value.into())
         }
 
         #[inline]


### PR DESCRIPTION
Hi Pauan,

This PR allows the `set` method to take `Into<A>` rather than `A`. Would you be open to merging this? Is there a (possibly very good) reason not to? Very open to discussion/improvement.