### PR TITLE
(add-signal-map-filter) Added filter for SignalMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pin-utils = "0.1.0"
 once_cell = "1.10.0"
 indoc = "2.0.1"
 criterion = { version = "0.4.0", features = [] }
+tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 
 [[bench]]
 name = "channel"

--- a/tests/signal_map.rs
+++ b/tests/signal_map.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
+use std::iter::FromIterator;
 use std::task::Poll;
+use futures_channel::mpsc::channel;
 use futures_signals::signal::{self, SignalExt};
-use futures_signals::signal_map::{self, MapDiff, SignalMapExt};
+use futures_signals::signal_map::{self, MapDiff, MutableBTreeMap, SignalMapExt};
 
 mod util;
 
@@ -234,4 +236,52 @@ fn key_cloned_empty() {
         Poll::Ready(Some(None)),
         Poll::Ready(None),
     ]);
+}
+
+#[tokio::test]
+async fn test_filter_map() {
+    use futures_util::StreamExt;
+
+    let input = MutableBTreeMap::from([(1, "1".to_string()), (2, "2".to_string()), (3, "3".to_string())]);
+    let output_signal = input.signal_map_cloned().filter(|v| v % 2 == 0);
+
+    let output: MutableBTreeMap<i32, String> = MutableBTreeMap::new();
+    let output_cloned = output.clone();
+
+    let (mut proceed_tx, mut proceed_rx) = channel(100);
+
+    tokio::spawn(
+        output_signal.for_each(move |change| {
+            let mut locked = output_cloned.lock_mut();
+
+            match change {
+                MapDiff::Replace { entries } => locked.replace_cloned(BTreeMap::from_iter(entries)),
+                MapDiff::Remove { key } => { locked.remove(&key); }
+                MapDiff::Insert { key, value } => { locked.insert_cloned(key, value); }
+                MapDiff::Clear {} => locked.clear(),
+                MapDiff::Update { key, value } => { locked.insert_cloned(key, value); }
+            }
+
+            proceed_tx.try_send(()).unwrap();
+
+            async {}
+        }));
+
+    proceed_rx.next().await.unwrap();
+
+    assert_eq!(output.lock_ref().len(), 1);
+    assert_eq!(output.lock_ref().get_key_value(&2), Some((&2, &"2".to_string())));
+
+    input.lock_mut().insert_cloned(42, "test".to_string());
+
+    proceed_rx.next().await.unwrap();
+
+    assert_eq!(output.lock_ref().len(), 2);
+    assert_eq!(output.lock_ref().get_key_value(&42), Some((&42, &"test".to_string())));
+
+    input.lock_mut().remove(&42);
+    proceed_rx.next().await.unwrap();
+
+    assert_eq!(output.lock_ref().len(), 1);
+    assert_eq!(output.lock_ref().get_key_value(&42), None);
 }


### PR DESCRIPTION
Adds filter to SignalMapExt. Not sure about unstable callback functions; i.e. if a callback has non-deterministic outcome for a given key, should we keep track of items that has been filtered etc. to correctly send Removed/inserted diffs based on the new result from the filter function or not