### PR TITLE
Failing flatten

### DIFF
--- a/src/signal_vec.rs
+++ b/src/signal_vec.rs
@@ -1113,6 +1113,46 @@ impl<A> std::fmt::Debug for Flatten<A>
     }
 }
 
+fn fill_removals<A>(
+    inner: &[FlattenState<A>],
+    index: usize,
+    pending: &mut PendingBuilder<VecDiff<A::Item>>,
+) where
+    A: SignalVec,
+{
+    let removed_len = inner[index].len;
+    let prev_len: usize = inner[..index].iter().map(|state| state.len).sum();
+    for index in (0..removed_len).rev() {
+        pending.push(VecDiff::RemoveAt {
+            index: prev_len + index,
+        });
+    }
+}
+
+fn fill_moves<A>(
+    inner: &[FlattenState<A>],
+    old_index: usize,
+    new_index: usize,
+    pending: &mut PendingBuilder<VecDiff<A::Item>>,
+) where
+    A: SignalVec,
+{
+    let moved_len = inner[old_index].len;
+    let old_prev_len: usize = inner[..old_index].iter().map(|state| state.len).sum();
+    let new_prev_len: usize = inner[..new_index].iter().map(|state| state.len).sum();
+
+    if new_index < old_index {
+        (0..moved_len).for_each(|_| pending.push(VecDiff::Move {
+            old_index: old_prev_len + moved_len - 1,
+            new_index: new_prev_len,
+        }));
+    } else {
+        (0..moved_len).for_each(|_| pending.push(VecDiff::Move {
+            old_index: old_prev_len,
+            new_index: new_prev_len + moved_len - 1,
+        }));
+    }}
+
 impl<A> SignalVec for Flatten<A>
     where A: SignalVec,
           A::Item: SignalVec {
@@ -1145,20 +1185,26 @@ impl<A> SignalVec for Flatten<A>
                             this.inner.insert(index, FlattenState::new(value));
                         },
                         VecDiff::UpdateAt { index, value } => {
+                            fill_removals(&this.inner, index, &mut pending);
                             this.inner[index] = FlattenState::new(value);
                         },
                         VecDiff::RemoveAt { index } => {
+                            fill_removals(&this.inner, index, &mut pending);
                             this.inner.remove(index);
                         },
                         VecDiff::Move { old_index, new_index } => {
-                            let value = this.inner.remove(old_index);
-                            this.inner.insert(new_index, value);
+                            if old_index != new_index {
+                                fill_moves(&this.inner, old_index, new_index, &mut pending);
+                                let value = this.inner.remove(old_index);
+                                this.inner.insert(new_index, value);
+                            }
                         },
                         VecDiff::Push { value } => {
                             this.inner.push(FlattenState::new(value));
                         },
                         VecDiff::Pop {} => {
-                            this.inner.pop().unwrap();
+                            let len = this.inner.pop().unwrap().len;
+                            (0..len).for_each(|_| pending.push(VecDiff::Pop {}));
                         },
                         VecDiff::Clear {} => {
                             this.inner.clear();
@@ -1207,7 +1253,6 @@ impl<A> SignalVec for Flatten<A>
         }
     }
 }
-
 
 #[pin_project]
 #[must_use = "Signals do nothing unless polled"]

--- a/tests/signal_vec.rs
+++ b/tests/signal_vec.rs
@@ -812,3 +812,78 @@ fn flatten_empty() {
         Poll::Ready(None),
     ]);
 }
+
+#[test]
+fn flatten_remove_immediate() {
+    let input = util::Source::new(vec![
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![
+                Poll::Ready(VecDiff::Replace { values: vec![42] }),
+            ]),
+        }),
+        Poll::Ready(VecDiff::RemoveAt { index: 0 }),
+    ]);
+
+    let output = input.flatten();
+
+    util::assert_signal_vec_eq(output, vec![
+        Poll::Pending,
+        Poll::Ready(None),
+    ]);
+}
+
+#[test]
+fn flatten_remove_delayed() {
+    let input = util::Source::new(vec![
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![
+                Poll::Ready(VecDiff::Replace { values: vec![42] }),
+            ]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::RemoveAt { index: 0 }),
+    ]);
+
+    let output = input.flatten();
+
+    util::assert_signal_vec_eq(output, vec![
+        Poll::Pending,
+        Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 42 })),
+        Poll::Ready(Some(VecDiff::RemoveAt { index: 0 })),
+        Poll::Ready(None),
+    ]);
+}
+
+#[test]
+fn flatten_update_inner() {
+    let input = util::Source::new(vec![
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![42] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::UpdateAt {
+            index: 0,
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![43] })]),
+        }),
+    ]);
+
+    let output = input.flatten();
+
+    util::assert_signal_vec_eq(
+        output,
+        vec![
+            Poll::Pending,
+            // should the sequence be this...
+            Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 42 })),
+            Poll::Ready(Some(VecDiff::RemoveAt { index: 0 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 43 })),
+            // ...or this?
+            // Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 42 })),
+            // Poll::Ready(Some(VecDiff::UpdateAt { index: 0, value: 43 })),
+            Poll::Ready(None),
+        ],
+    );
+}

--- a/tests/signal_vec.rs
+++ b/tests/signal_vec.rs
@@ -876,13 +876,97 @@ fn flatten_update_inner() {
         output,
         vec![
             Poll::Pending,
-            // should the sequence be this...
             Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 42 })),
             Poll::Ready(Some(VecDiff::RemoveAt { index: 0 })),
             Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 43 })),
-            // ...or this?
-            // Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 42 })),
-            // Poll::Ready(Some(VecDiff::UpdateAt { index: 0, value: 43 })),
+            Poll::Ready(None),
+        ],
+    );
+}
+
+#[test]
+fn flatten_move_up() {
+    let input = util::Source::new(vec![
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![2, 3, 4] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![12, 13, 14] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![22, 23, 24] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::Move {
+            old_index: 0, new_index: 2,
+        }),
+    ]);
+
+    let output = input.flatten();
+
+    util::assert_signal_vec_eq(
+        output,
+        vec![
+            Poll::Pending,
+            Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 2 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 1, value: 3 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 2, value: 4 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 3, value: 12 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 4, value: 13 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 5, value: 14 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 6, value: 22 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 7, value: 23 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 8, value: 24 })),
+            Poll::Ready(Some(VecDiff::Move { old_index: 0, new_index: 8 })),
+            Poll::Ready(Some(VecDiff::Move { old_index: 0, new_index: 8 })),
+            Poll::Ready(Some(VecDiff::Move { old_index: 0, new_index: 8 })),
+            Poll::Ready(None),
+        ],
+    );
+}
+
+#[test]
+fn flatten_move_down() {
+    let input = util::Source::new(vec![
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![2, 3, 4] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![12, 13, 14] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::Push {
+            value: util::Source::new(vec![Poll::Ready(VecDiff::Replace { values: vec![22, 23, 24] })]),
+        }),
+        Poll::Pending,
+        Poll::Ready(VecDiff::Move {
+            old_index: 2, new_index: 0,
+        }),
+    ]);
+
+    let output = input.flatten();
+
+    util::assert_signal_vec_eq(
+        output,
+        vec![
+            Poll::Pending,
+            Poll::Ready(Some(VecDiff::InsertAt { index: 0, value: 2 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 1, value: 3 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 2, value: 4 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 3, value: 12 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 4, value: 13 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 5, value: 14 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 6, value: 22 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 7, value: 23 })),
+            Poll::Ready(Some(VecDiff::InsertAt { index: 8, value: 24 })),
+            Poll::Ready(Some(VecDiff::Move { old_index: 8, new_index: 0 })),
+            Poll::Ready(Some(VecDiff::Move { old_index: 8, new_index: 0 })),
+            Poll::Ready(Some(VecDiff::Move { old_index: 8, new_index: 0 })),
             Poll::Ready(None),
         ],
     );


### PR DESCRIPTION
Tests of failing flatten. In general, when outer signal_vec item is removed/replaced, its items are not removed when flattening. This PR only adds tests, solution seems not to be straightforward.