### PR TITLE
Elided lifetimes added -- resolves rustc 1.89.0 lint about mismatched lifetime syntaxes

### DIFF
--- a/src/signal/mutable.rs
+++ b/src/signal/mutable.rs
@@ -172,7 +172,7 @@ pub struct ReadOnlyMutable<A>(Arc<MutableState<A>>);
 impl<A> ReadOnlyMutable<A> {
     // TODO return Result ?
     #[inline]
-    pub fn lock_ref(&self) -> MutableLockRef<A> {
+    pub fn lock_ref(&self) -> MutableLockRef<'_, A> {
         MutableLockRef {
             lock: self.0.lock.read().unwrap(),
         }
@@ -307,7 +307,7 @@ impl<A> Mutable<A> {
     // TODO lots of unit tests to verify that it only notifies when the object is mutated
     // TODO return Result ?
     // TODO should this inline ?
-    pub fn lock_mut(&self) -> MutableLockMut<A> {
+    pub fn lock_mut(&self) -> MutableLockMut<'_, A> {
         MutableLockMut {
             mutated: false,
             lock: self.state().lock.write().unwrap(),

--- a/src/signal_map.rs
+++ b/src/signal_map.rs
@@ -814,7 +814,7 @@ mod mutable_btree_map {
 
         // TODO return Result ?
         #[inline]
-        pub fn lock_ref(&self) -> MutableBTreeMapLockRef<K, V> {
+        pub fn lock_ref(&self) -> MutableBTreeMapLockRef<'_, K, V> {
             MutableBTreeMapLockRef {
                 lock: self.0.read().unwrap(),
             }
@@ -822,7 +822,7 @@ mod mutable_btree_map {
 
         // TODO return Result ?
         #[inline]
-        pub fn lock_mut(&self) -> MutableBTreeMapLockMut<K, V> {
+        pub fn lock_mut(&self) -> MutableBTreeMapLockMut<'_, K, V> {
             MutableBTreeMapLockMut {
                 lock: self.0.write().unwrap(),
             }

--- a/src/signal_vec.rs
+++ b/src/signal_vec.rs
@@ -3384,7 +3384,7 @@ mod mutable_vec {
 
         // TODO return Result ?
         #[inline]
-        pub fn lock_ref(&self) -> MutableVecLockRef<A> {
+        pub fn lock_ref(&self) -> MutableVecLockRef<'_, A> {
             MutableVecLockRef {
                 lock: self.0.read().unwrap(),
             }
@@ -3392,7 +3392,7 @@ mod mutable_vec {
 
         // TODO return Result ?
         #[inline]
-        pub fn lock_mut(&self) -> MutableVecLockMut<A> {
+        pub fn lock_mut(&self) -> MutableVecLockMut<'_, A> {
             MutableVecLockMut {
                 lock: self.0.write().unwrap(),
             }


### PR DESCRIPTION
https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint